### PR TITLE
feat: add copy URL button to history items

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -467,7 +467,8 @@ async function showHistoryPanel() {
 
     const item = document.createElement('div');
     item.className = `history-item ${isPhish ? 'hist-phish' : 'hist-safe'}`;
-    item.innerHTML = `
+    item.innerHTML = 
+           `   
       <div class="hist-dot ${isPhish ? 'phishing' : 'safe'}"></div>
       <div class="hist-info">
         <div class="hist-url">${escHtml(shortenUrl(entry.url))}</div>
@@ -478,10 +479,23 @@ async function showHistoryPanel() {
       </div>
       <div class="hist-conf">${pct}%</div>
     `;
-    el.historyList.appendChild(item);
-  });
-}
+        const copyBtn = document.createElement("button");
+        copyBtn.className = "copy-btn";
+        copyBtn.textContent = "📋";
 
+        copyBtn.addEventListener("click", async () => {
+          await navigator.clipboard.writeText(entry.url);
+          copyBtn.textContent = "✅";
+
+          setTimeout(() => {
+            copyBtn.textContent = "📋";
+          }, 1500);
+        });
+
+        item.appendChild(copyBtn);
+        el.historyList.appendChild(item);
+      });
+    }
 function showMainPanel() {
   el.historyView.classList.add('hidden');
   el.mainView.classList.remove('hidden');

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -612,3 +612,16 @@ body {
 ::-webkit-scrollbar { width: 4px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--border-2); border-radius: 99px; }
+
+/* copy button*/
+.copy-btn {
+  margin-left: 8px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.copy-btn:hover {
+  opacity: 0.7;
+}


### PR DESCRIPTION
i added a copy URL button to each scan history item.

changes-
added the copy button to history items
used clipboard API to copy URL
added success feedback icon (green tick)
styled the button in styles.css

Fixes #1