### PR TITLE
adding phishing confidence percentage to extension badge

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -107,9 +107,9 @@ function localAnalysisBackground(url) {
 /* ══════════════════════════════════════════════════════════════
    BADGE MANAGEMENT
    ══════════════════════════════════════════════════════════════ */
-function updateBadge(tabId, label) {
+function updateBadge(tabId, label, confidence) {
   if (label === 'phishing') {
-    setBadgeDanger(tabId);
+    setBadgeDanger(tabId, confidence);
   } else {
     setBadgeSafe(tabId);
   }
@@ -120,8 +120,9 @@ function setBadgeSafe(tabId) {
   chrome.action.setBadgeBackgroundColor({ color: '#10b981', tabId });
 }
 
-function setBadgeDanger(tabId) {
-  chrome.action.setBadgeText({ text: '!', tabId });
+function setBadgeDanger(tabId, confidence) {
+  const pct = Math.round(confidence);
+  chrome.action.setBadgeText({ text: pct + '%', tabId });
   chrome.action.setBadgeBackgroundColor({ color: '#ef4444', tabId });
 }
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -467,7 +467,8 @@ async function showHistoryPanel() {
 
     const item = document.createElement('div');
     item.className = `history-item ${isPhish ? 'hist-phish' : 'hist-safe'}`;
-    item.innerHTML = `
+    item.innerHTML = 
+           `   
       <div class="hist-dot ${isPhish ? 'phishing' : 'safe'}"></div>
       <div class="hist-info">
         <div class="hist-url">${escHtml(shortenUrl(entry.url))}</div>
@@ -478,10 +479,23 @@ async function showHistoryPanel() {
       </div>
       <div class="hist-conf">${pct}%</div>
     `;
-    el.historyList.appendChild(item);
-  });
-}
+        const copyBtn = document.createElement("button");
+        copyBtn.className = "copy-btn";
+        copyBtn.textContent = "📋";
 
+        copyBtn.addEventListener("click", async () => {
+          await navigator.clipboard.writeText(entry.url);
+          copyBtn.textContent = "✅";
+
+          setTimeout(() => {
+            copyBtn.textContent = "📋";
+          }, 1500);
+        });
+
+        item.appendChild(copyBtn);
+        el.historyList.appendChild(item);
+      });
+    }
 function showMainPanel() {
   el.historyView.classList.add('hidden');
   el.mainView.classList.remove('hidden');

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -612,3 +612,16 @@ body {
 ::-webkit-scrollbar { width: 4px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--border-2); border-radius: 99px; }
+
+/* copy button*/
+.copy-btn {
+  margin-left: 8px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.copy-btn:hover {
+  opacity: 0.7;
+}


### PR DESCRIPTION
this feature enhances the extension badge to display the phishing confidence percentage for flagged URLs.

i updated updateBadge() to pass confidence score
and odified setBadgeDanger() to display percentage 
retained ✓ badge for safe sites

(i tested it using extensions)
<img width="123" height="60" alt="image" src="https://github.com/user-attachments/assets/11338459-e97e-4137-ba19-c74587b4268d" />

Fixes #5 