### PR TITLE
feat: add CSV download button for URL check history

### DIFF
--- a/phishguard-web/streamlit_app.py
+++ b/phishguard-web/streamlit_app.py
@@ -8,6 +8,8 @@ import streamlit as st
 import re
 import math
 import time
+import pandas as pd
+import io
 from urllib.parse import urlparse, parse_qs
 
 # ══════════════════════════════════════════════════════════════
@@ -412,6 +414,18 @@ if analyze and url_input.strip():
     </div>
     """, unsafe_allow_html=True)
 
+    # ── CSV DOWNLOAD BUTTON (main page) ───────────────────────
+    if st.session_state.history:
+        csv_buffer = io.StringIO()
+        pd.DataFrame(st.session_state.history).to_csv(csv_buffer, index=False)
+        st.download_button(
+            label="⬇️ Download History as CSV",
+            data=csv_buffer.getvalue(),
+            file_name="phishguard_history.csv",
+            mime="text/csv",
+            use_container_width=True,
+        )
+
 elif analyze and not url_input.strip():
     st.warning("Please enter a URL to analyze.")
 
@@ -430,6 +444,18 @@ with st.sidebar:
         if st.button("🗑️ Clear History", use_container_width=True):
             st.session_state.history = []
             st.rerun()
+
+        # ── CSV DOWNLOAD BUTTON ────────────────────────────────
+        csv_buffer = io.StringIO()
+        pd.DataFrame(st.session_state.history).to_csv(csv_buffer, index=False)
+        st.download_button(
+            label="⬇️ Download History as CSV",
+            data=csv_buffer.getvalue(),
+            file_name="phishguard_history.csv",
+            mime="text/csv",
+            use_container_width=True,
+        )
+        # ──────────────────────────────────────────────────────
 
         for entry in st.session_state.history:
             is_p  = entry['label'] == 'phishing'


### PR DESCRIPTION
## What does this PR do?
This PR adds a CSV export feature to the PhishGuard web app that allows users to download their URL scan history.  
Previously, users could view scan results in the app but had no way to save or export them. This PR fixes that by adding download button that generates a CSV file containing the scan data.

## Changes
- Added CSV download functionality for URL scan history
- Added download button on the main page
- CSV includes: url, label, confidence, score

## Notes
- Button appears after at least one URL is analyzed
- Uses pandas to convert session history into CSV format

## Screenshots
<img width="789" height="580" alt="Screenshot 2026-04-08 021956" src="https://github.com/user-attachments/assets/8f506a80-1520-4081-aa35-7a50d7205436" />
<img width="506" height="146" alt="Screenshot 2026-04-08 022211" src="https://github.com/user-attachments/assets/e9b232e0-5e45-49ac-b9d2-909d0e3d17bc" />

## Related Issue
Closes #25