### PR TITLE
feat: add confidence progress bar with color-based risk display using st.progress()

### DIFF
--- a/phishguard-web/streamlit_app.py
+++ b/phishguard-web/streamlit_app.py
@@ -340,18 +340,29 @@ if analyze and url_input.strip():
     m4.metric("KEYWORDS",    features['keyword_count'])
 
     # ── CONFIDENCE BAR ─────────────────────────────────────────
-    st.markdown("<p style='font-size:10px;letter-spacing:0.1em;color:#454d66;margin-top:16px;margin-bottom:6px;'>CONFIDENCE SCORE</p>", unsafe_allow_html=True)
-    bar_color = "#ef4444" if pct >= 70 else "#f59e0b" if pct >= 45 else "#10b981"
+    if pct >= 70:
+        risk_label = "High Risk"
+        risk_color = "#ef4444"
+    elif pct >= 45:
+        risk_label = "Moderate Risk"
+        risk_color = "#f59e0b"
+    else:
+        risk_label = "Low Risk"
+        risk_color = "#10b981"
+
     st.markdown(f"""
-    <div style="background:#161b26;border-radius:99px;height:8px;overflow:hidden;margin-bottom:4px;">
-      <div style="width:{pct}%;height:100%;background:{bar_color};
-                  border-radius:99px;transition:width 0.8s ease;"></div>
-    </div>
-    <p style="font-size:10px;color:#454d66;">
-      {'High risk — ' if pct >= 70 else 'Moderate risk — ' if pct >= 45 else 'Low risk — '}
-      model is {pct}% confident in this prediction
+    <p style='font-size:10px;letter-spacing:0.1em;color:#454d66;margin-top:16px;margin-bottom:6px;'>
+      CONFIDENCE SCORE &nbsp;·&nbsp;
+      <span style='color:{risk_color};font-weight:600;'>● {risk_label}</span>
     </p>
+    <style>
+    div[data-testid="stProgress"] > div > div > div > div {{
+        background-color: {risk_color} !important;
+    }}
+    </style>
     """, unsafe_allow_html=True)
+    st.progress(confidence)
+    st.markdown(f"<p style='font-size:10px;color:#454d66;margin-top:4px;'>Model is {pct}% confident in this prediction</p>", unsafe_allow_html=True)
 
     st.divider()
 


### PR DESCRIPTION
##what does this PR do?

This PR replaces the custom HTML confidence bar with Streamlit's native st.progress() component with color-based risk display.

Fixes #22 

## Changes
- Replaced custom HTML bar with st.progress()
- Added color-based risk indicator: 🔴 High Risk / 🟡 Moderate Risk / 🟢 Low Risk
- Added dot indicator (●) next to risk label
- CSS used to override st.progress() default blue color to match risk level

##Screenshots
<img width="762" height="533" alt="Screenshot 2026-04-09 085227" src="https://github.com/user-attachments/assets/57115bbe-1d40-4f8e-a397-1b5b47e098f2" />
<img width="785" height="516" alt="Screenshot 2026-04-09 085205" src="https://github.com/user-attachments/assets/3b938576-b82a-41e8-87f7-e3da53a7d7a9" />
<img width="760" height="527" alt="Screenshot 2026-04-09 085244" src="https://github.com/user-attachments/assets/5e55177e-dd11-4f06-9eec-415fd682a158" />
